### PR TITLE
Fix install step

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,7 +40,7 @@ download_release() {
   version="$1"
   filename="$2"
 
-  url="$GH_REPO/archive/v${version}.tar.gz"
+  url="$GH_REPO/archive/refs/tags/${version}.tar.gz"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -50,19 +50,21 @@ install_version() {
   local install_type="$1"
   local version="$2"
   local install_path="${3%/bin}/bin"
+  local install_root_path="$3"
 
   if [ "$install_type" != "version" ]; then
     fail "asdf-$TOOL_NAME supports release installs only"
   fi
 
   (
-    mkdir -p "$install_path"
-    cp -r "$ASDF_DOWNLOAD_PATH"/* "$install_path"
-
     # TODO: Assert angular executable exists.
     local tool_cmd
     tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
-    npm install --prefix "$install_path" "@angular/cli@$version"
+
+    mkdir -p "$install_root_path"
+    npm install --prefix "$install_root_path" "@angular/cli@$version"
+    ln -s "$install_root_path"/node_modules/.bin "$install_path"
+
     test -x "$install_path/$tool_cmd" || fail "Expected $install_path/$tool_cmd to be executable."
 
     echo "$TOOL_NAME $version installation was successful!"


### PR DESCRIPTION
- It wasnt able to download angular packages. The path for each release file is `$GH_REPO/archive/refs/tags/${version}.tar.gz`
- It wasnt able to link the new angular version installed to asdf. The `ng` binary wasnt in `$ASDF_INSTALL_PATH/bin` 